### PR TITLE
Add MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jesse Vincent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This repository does not currently include a license file, even though `package.json` already declares `"license": "MIT"` and lists `LICENSE` among the files to publish. Without an explicit LICENSE file in the repository, downstream users, packagers, and automated license scanners cannot reliably confirm the terms under which the code may be used or redistributed.

This PR adds a standard `LICENSE` file containing the MIT License text, with the copyright line:

```
Copyright (c) 2025 Jesse Vincent
```

The year (2025) matches the year of this repository's first commit.

The MIT license body was copied verbatim from an existing `LICENSE` file in another repository owned by the same author (`obra/superpowers`), with no changes to the license text itself — only the copyright line, which was already identical in the source file, so no substitution was actually needed.

No other files are modified.
